### PR TITLE
Fix: Improve Dockerization using pnpm and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,33 @@
-{env
-    "name": "binance-mcp",
-    "version": "1.0.8",
-    "main": "index.js",
-    "type": "module",
-    "bin": {
-        "binance-mcp": "./build/index.js"    },    "scripts": {        "test": "node test/testServer.js",        "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",        "init": "node ./build/init.js",        "init:build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\" && node ./build/init.js",        "publish:auto": "node scripts/publish.cjs",        "docker:build": "docker build -t binance-mcp .",        "docker:run": "docker run -p 3000:3000 --env-file .env binance-mcp",        "docker:compose": "docker-compose up -d",        "docker:compose:build": "docker-compose up -d --build",        "docker:logs": "docker-compose logs -f"    },    "files": [        "build"    ],    "keywords": [        "binance-smart-chain",        "bsc",        "blockchain",        "web3",        "cryptocurrency",        "defi",        "model-context-protocol",        "mcp",        "claude-integration",        "ai-agents",        "token-transfers",        "smart-contracts",        "pancakeswap",        "bep20",        "swap",        "liquidity",        "wallet-management",        "blockchain-tools",        "crypto-cli",        "defi-tools",        "meme-tokens",        "token-deployment",        "blockchain-development",        "web3-infrastructure",        "crypto-automation",        "token-security",        "moralis-integration",        "bnb-chain"    ],    "author": "",    "license": "MIT",    "description": "",    "devDependencies": {        "@types/figlet": "^1.7.0",        "@types/fs-extra": "^11.0.4",        "@types/node": "^22.10.0",        "@types/prompts": "^2.4.9",        "typescript": "^5.8.2"    },    "dependencies": {        "@binance/algo": "^1.0.0",        "@binance/c2c": "^1.0.1",        "@binance/connector": "^3.6.1",        "@binance/convert": "^1.0.1",        "@binance/copy-trading": "^1.0.1",        "@binance/dual-investment": "^2.0.0",        "@binance/fiat": "^2.0.0",        "@binance/mining": "^2.0.0",        "@binance/nft": "^2.0.0",        "@binance/pay": "^2.0.0",        "@binance/rebate": "^2.0.0",        "@binance/simple-earn": "^1.0.0",        "@binance/spot": "^1.0.0",        "@binance/staking": "^2.0.0",        "@binance/wallet": "^2.0.1",        "@binance/vip-loan": "^2.0.0",        "@modelcontextprotocol/sdk": "^1.8.0",        "chalk": "^5.4.1",        "dotenv": "^16.4.7",        "figlet": "^1.8.0",
-        "fs-extra": "^11.3.0",
-        "ora": "^8.2.0",
-        "prompts": "^2.4.2"
-    }
-}
+# Node.js
+node_modules
+npm-debug.log
+*.log
+*.env
+.env
+.env.*
+!/.env.example
+
+# TypeScript
+*.tsbuildinfo
+
+# Build output
+build
+dist
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Git
+.git
+.gitignore
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM node:18-slim
 # Create app directory
 WORKDIR /usr/src/app
 
+RUN npm install -g pnpm
+
 # Copy package files
-COPY package*.json ./
+COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies
-RUN npm install
+RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
This commit addresses issues in the Dockerization setup:

1.  **Dockerfile updated to use pnpm:**
    *   Ensures `pnpm` is installed globally in the Docker image.
    *   Copies `package.json` and `pnpm-lock.yaml` for dependency installation.
    *   Uses `pnpm install --frozen-lockfile` to install dependencies, respecting the pnpm lockfile for consistent builds. This aligns the Docker build process with projects using pnpm as the package manager.

2.  **.dockerignore corrected and updated:**
    *   The previous `.dockerignore` file had incorrect content (mirrored package.json).
    *   It has been replaced with a standard set of ignore patterns for Node.js/TypeScript projects.
    *   Crucially, `node_modules` and `build` directories are now ignored, preventing local artifacts from interfering with the Docker build context and ensuring a cleaner build.

These changes lead to a more robust, consistent, and correct Docker build process, especially for developers using pnpm. The `docker-compose.yml` file was reviewed and deemed suitable for typical development workflows without requiring changes in this iteration.